### PR TITLE
Feature/1203004461810845 improvement prevent multiple owner data retrieval when fetching data

### DIFF
--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -13,14 +13,19 @@ pub enum EntityError {
 }
 
 pub trait Rbac<AccountId, EntityId> {
-    fn generate_key(entity: &EntityId, tag: Tag) -> [u8; 32];
-    fn is_owner(owner: &AccountId, key: &[u8; 32]) -> Result<(), EntityError>;
-    fn get_user_roles(user_id: EntityId) -> Option<Vec<Role2User<EntityId>>>;
-    fn get_user_groups(user_id: EntityId) -> Option<Vec<User2Group<EntityId>>>;
-    fn get_group_roles(group_id: EntityId) -> Option<Vec<Role2Group<EntityId>>>;
-    fn get_role_permissions(role_id: EntityId) -> Option<Vec<Permission2Role<EntityId>>>;
-    fn get_user_permissions(user_id: EntityId) -> Option<Vec<Entity<EntityId>>>;
-    fn get_group_permissions(group_id: EntityId) -> Option<Vec<Entity<EntityId>>>;
+    fn generate_key(owner: &AccountId, entity: &EntityId, tag: Tag) -> [u8; 32];
+    fn get_user_roles(owner: &AccountId, user_id: EntityId) -> Option<Vec<Role2User<EntityId>>>;
+    fn get_user_groups(owner: &AccountId, user_id: EntityId) -> Option<Vec<User2Group<EntityId>>>;
+    fn get_group_roles(owner: &AccountId, group_id: EntityId) -> Option<Vec<Role2Group<EntityId>>>;
+    fn get_role_permissions(
+        owner: &AccountId,
+        role_id: EntityId,
+    ) -> Option<Vec<Permission2Role<EntityId>>>;
+    fn get_user_permissions(owner: &AccountId, user_id: EntityId) -> Option<Vec<Entity<EntityId>>>;
+    fn get_group_permissions(
+        owner: &AccountId,
+        group_id: EntityId,
+    ) -> Option<Vec<Entity<EntityId>>>;
     fn create_role_to_user(
         owner: &AccountId,
         role_id: EntityId,
@@ -64,8 +69,8 @@ pub trait Rbac<AccountId, EntityId> {
 }
 
 pub trait Role<AccountId, EntityId> {
-    fn get_role(role_id: EntityId) -> Option<Entity<EntityId>>;
-    fn get_roles() -> Vec<Entity<EntityId>>;
+    fn get_role(owner: &AccountId, role_id: EntityId) -> Option<Entity<EntityId>>;
+    fn get_roles(owner: &AccountId) -> Vec<Entity<EntityId>>;
     fn create_role(owner: &AccountId, role_id: EntityId, name: &[u8]) -> Result<(), EntityError>;
     fn update_existing_role(
         owner: &AccountId,
@@ -76,8 +81,8 @@ pub trait Role<AccountId, EntityId> {
 }
 
 pub trait Permission<AccountId, EntityId> {
-    fn get_permission(permission_id: EntityId) -> Option<Entity<EntityId>>;
-    fn get_permissions() -> Vec<Entity<EntityId>>;
+    fn get_permission(owner: &AccountId, permission_id: EntityId) -> Option<Entity<EntityId>>;
+    fn get_permissions(owner: &AccountId) -> Vec<Entity<EntityId>>;
     fn create_permission(
         owner: &AccountId,
         permission_id: EntityId,
@@ -95,8 +100,8 @@ pub trait Permission<AccountId, EntityId> {
 }
 
 pub trait Group<AccountId, EntityId> {
-    fn get_group(group_id: EntityId) -> Option<Entity<EntityId>>;
-    fn get_groups() -> Vec<Entity<EntityId>>;
+    fn get_group(owner: &AccountId, group_id: EntityId) -> Option<Entity<EntityId>>;
+    fn get_groups(owner: &AccountId) -> Vec<Entity<EntityId>>;
     fn create_group(owner: &AccountId, group_id: EntityId, name: &[u8]) -> Result<(), EntityError>;
     fn update_existing_group(
         owner: &AccountId,

--- a/src/rbac.rs
+++ b/src/rbac.rs
@@ -14,6 +14,8 @@ pub enum EntityError {
 
 pub trait Rbac<AccountId, EntityId> {
     fn generate_key(owner: &AccountId, entity: &EntityId, tag: Tag) -> [u8; 32];
+    fn get_entity(key: [u8; 32]) -> Option<Entity<EntityId>>;
+    fn check_entity_exists(key: [u8; 32]) -> bool;
     fn get_user_roles(owner: &AccountId, user_id: EntityId) -> Option<Vec<Role2User<EntityId>>>;
     fn get_user_groups(owner: &AccountId, user_id: EntityId) -> Option<Vec<User2Group<EntityId>>>;
     fn get_group_roles(owner: &AccountId, group_id: EntityId) -> Option<Vec<Role2Group<EntityId>>>;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -50,7 +50,7 @@ fn update_role_test() {
         let name = b"CAN_UPDATE";
         assert_noop!(
             PeaqRBAC::update_role(Origin::signed(origin2), role_id, name.to_vec()),
-            Error::<Test>::EntityAuthorizationFailed
+            Error::<Test>::EntityDoesNotExist
         );
 
         assert_ok!(PeaqRBAC::update_role(
@@ -87,7 +87,7 @@ fn disable_role_test() {
         // Test for removal of role not owned by origin
         assert_noop!(
             PeaqRBAC::disable_role(Origin::signed(origin2), role_id),
-            Error::<Test>::EntityAuthorizationFailed
+            Error::<Test>::EntityDoesNotExist
         );
 
         assert_ok!(PeaqRBAC::disable_role(Origin::signed(origin), role_id,));
@@ -114,12 +114,16 @@ fn fetch_role_test() {
             name.to_vec(),
         ));
 
-        assert_ok!(PeaqRBAC::fetch_role(Origin::signed(origin), role_id,));
+        assert_ok!(PeaqRBAC::fetch_role(
+            Origin::signed(origin),
+            origin,
+            role_id,
+        ));
 
         // Test for fetching non-existing role
         let role_id = *b"23676474666576474646673646376638";
         assert_noop!(
-            PeaqRBAC::fetch_role(Origin::signed(origin), role_id),
+            PeaqRBAC::fetch_role(Origin::signed(origin), origin, role_id),
             Error::<Test>::EntityDoesNotExist
         );
     });
@@ -145,7 +149,7 @@ fn fetch_roles_test() {
             name.to_vec(),
         ));
 
-        assert_ok!(PeaqRBAC::fetch_roles(Origin::signed(origin),));
+        assert_ok!(PeaqRBAC::fetch_roles(Origin::signed(origin), origin));
     });
 }
 
@@ -169,7 +173,7 @@ fn assign_role_to_user_test() {
         // Test for assigning role not owned by origin
         assert_noop!(
             PeaqRBAC::assign_role_to_user(Origin::signed(origin2), role_id, user_id),
-            Error::<Test>::EntityAuthorizationFailed
+            Error::<Test>::EntityDoesNotExist
         );
 
         assert_ok!(PeaqRBAC::assign_role_to_user(
@@ -219,7 +223,7 @@ fn unassign_role_to_user_test() {
         // Test for removing role not owned by origin
         assert_noop!(
             PeaqRBAC::unassign_role_to_user(Origin::signed(origin2), role_id, user_id),
-            Error::<Test>::EntityAuthorizationFailed
+            Error::<Test>::EntityDoesNotExist
         );
 
         assert_ok!(PeaqRBAC::unassign_role_to_user(
@@ -269,13 +273,13 @@ fn assign_role_to_group_test() {
         // Test for assigning role not owned by origin
         assert_noop!(
             PeaqRBAC::assign_role_to_group(Origin::signed(origin2), role_id, group_id),
-            Error::<Test>::EntityAuthorizationFailed
+            Error::<Test>::EntityDoesNotExist
         );
 
         // Test for assigning group not owned by origin
         assert_noop!(
             PeaqRBAC::assign_role_to_group(Origin::signed(origin), role_id, group_id2),
-            Error::<Test>::EntityAuthorizationFailed
+            Error::<Test>::EntityDoesNotExist
         );
 
         assert_ok!(PeaqRBAC::assign_role_to_group(
@@ -338,7 +342,7 @@ fn unassign_role_to_group_test() {
         // Test for removing role not owned by origin
         assert_noop!(
             PeaqRBAC::unassign_role_to_group(Origin::signed(origin2), role_id, group_id),
-            Error::<Test>::EntityAuthorizationFailed
+            Error::<Test>::EntityDoesNotExist
         );
 
         assert_ok!(PeaqRBAC::unassign_role_to_group(
@@ -376,12 +380,16 @@ fn fetch_user_roles_test() {
             user_id
         ));
 
-        assert_ok!(PeaqRBAC::fetch_user_roles(Origin::signed(origin), user_id));
+        assert_ok!(PeaqRBAC::fetch_user_roles(
+            Origin::signed(origin),
+            origin,
+            user_id
+        ));
 
         // Test for non-existing role to user relationship
         let user_id = *b"15676474666576474646673646376637";
         assert_noop!(
-            PeaqRBAC::fetch_user_roles(Origin::signed(origin), user_id),
+            PeaqRBAC::fetch_user_roles(Origin::signed(origin), origin, user_id),
             Error::<Test>::EntityDoesNotExist
         );
     });
@@ -436,7 +444,7 @@ fn update_permission_test() {
         let name = b"CAN_UPDATE";
         assert_noop!(
             PeaqRBAC::update_permission(Origin::signed(origin2), permission_id, name.to_vec()),
-            Error::<Test>::EntityAuthorizationFailed
+            Error::<Test>::EntityDoesNotExist
         );
 
         assert_ok!(PeaqRBAC::update_permission(
@@ -473,7 +481,7 @@ fn disable_permission_test() {
         // Test for removal of permission not owned by origin
         assert_noop!(
             PeaqRBAC::disable_permission(Origin::signed(origin2), permission_id),
-            Error::<Test>::EntityAuthorizationFailed
+            Error::<Test>::EntityDoesNotExist
         );
 
         assert_ok!(PeaqRBAC::disable_permission(
@@ -505,13 +513,14 @@ fn fetch_permission_test() {
 
         assert_ok!(PeaqRBAC::fetch_permission(
             Origin::signed(origin),
+            origin,
             permission_id,
         ));
 
         // Test for fetching non-existing permission
         let permission_id = *b"44464667364637663721676474666577";
         assert_noop!(
-            PeaqRBAC::fetch_permission(Origin::signed(origin), permission_id),
+            PeaqRBAC::fetch_permission(Origin::signed(origin), origin, permission_id),
             Error::<Test>::EntityDoesNotExist
         );
     });
@@ -537,7 +546,7 @@ fn fetch_permissions_test() {
             name.to_vec(),
         ));
 
-        assert_ok!(PeaqRBAC::fetch_permissions(Origin::signed(origin),));
+        assert_ok!(PeaqRBAC::fetch_permissions(Origin::signed(origin), origin));
     });
 }
 
@@ -568,7 +577,7 @@ fn assign_permission_to_role_test() {
         // Test for assigning permission not owned by origin
         assert_noop!(
             PeaqRBAC::assign_permission_to_role(Origin::signed(origin2), permission_id, role_id),
-            Error::<Test>::EntityAuthorizationFailed
+            Error::<Test>::EntityDoesNotExist
         );
 
         assert_ok!(PeaqRBAC::assign_permission_to_role(
@@ -625,7 +634,7 @@ fn unassign_permission_to_role_test() {
         // Test for removing permission not owned by origin
         assert_noop!(
             PeaqRBAC::unassign_permission_to_role(Origin::signed(origin2), permission_id, role_id),
-            Error::<Test>::EntityAuthorizationFailed
+            Error::<Test>::EntityDoesNotExist
         );
 
         assert_ok!(PeaqRBAC::unassign_permission_to_role(
@@ -672,13 +681,14 @@ fn fetch_role_permissions_test() {
 
         assert_ok!(PeaqRBAC::fetch_role_permissions(
             Origin::signed(origin),
+            origin,
             role_id
         ));
 
         // Test for non-existing permission to role relationship
         let role_id = *b"15464667364637663721676474666577";
         assert_noop!(
-            PeaqRBAC::fetch_role_permissions(Origin::signed(origin), role_id),
+            PeaqRBAC::fetch_role_permissions(Origin::signed(origin), origin, role_id),
             Error::<Test>::EntityDoesNotExist
         );
     });
@@ -733,7 +743,7 @@ fn update_group_test() {
         let name = b"Admins";
         assert_noop!(
             PeaqRBAC::update_group(Origin::signed(origin2), group_id, name.to_vec()),
-            Error::<Test>::EntityAuthorizationFailed
+            Error::<Test>::EntityDoesNotExist
         );
 
         assert_ok!(PeaqRBAC::update_group(
@@ -770,7 +780,7 @@ fn disable_group_test() {
         // Test for removal of group not owned by origin
         assert_noop!(
             PeaqRBAC::disable_group(Origin::signed(origin2), group_id),
-            Error::<Test>::EntityAuthorizationFailed
+            Error::<Test>::EntityDoesNotExist
         );
 
         assert_ok!(PeaqRBAC::disable_group(Origin::signed(origin), group_id,));
@@ -797,12 +807,16 @@ fn fetch_group_test() {
             name.to_vec(),
         ));
 
-        assert_ok!(PeaqRBAC::fetch_group(Origin::signed(origin), group_id,));
+        assert_ok!(PeaqRBAC::fetch_group(
+            Origin::signed(origin),
+            origin,
+            group_id,
+        ));
 
         // Test for fetching non-existing group
         let group_id = *b"14663776474646673646665421676477";
         assert_noop!(
-            PeaqRBAC::fetch_group(Origin::signed(origin), group_id),
+            PeaqRBAC::fetch_group(Origin::signed(origin), origin, group_id),
             Error::<Test>::EntityDoesNotExist
         );
     });
@@ -829,7 +843,7 @@ fn fetch_groups_test() {
             name.to_vec(),
         ));
 
-        assert_ok!(PeaqRBAC::fetch_groups(Origin::signed(origin),));
+        assert_ok!(PeaqRBAC::fetch_groups(Origin::signed(origin), origin,));
     });
 }
 
@@ -853,7 +867,7 @@ fn assign_user_to_group_test() {
         // Test for assigning group not owned by origin
         assert_noop!(
             PeaqRBAC::assign_user_to_group(Origin::signed(origin2), user_id, group_id),
-            Error::<Test>::EntityAuthorizationFailed
+            Error::<Test>::EntityDoesNotExist
         );
 
         assert_ok!(PeaqRBAC::assign_user_to_group(
@@ -903,7 +917,7 @@ fn unassign_user_to_group_test() {
         // Test for removing group not owned by origin
         assert_noop!(
             PeaqRBAC::unassign_user_to_group(Origin::signed(origin2), user_id, group_id),
-            Error::<Test>::EntityAuthorizationFailed
+            Error::<Test>::EntityDoesNotExist
         );
 
         assert_ok!(PeaqRBAC::unassign_user_to_group(
@@ -941,12 +955,16 @@ fn fetch_user_groups_test() {
             group_id
         ));
 
-        assert_ok!(PeaqRBAC::fetch_user_groups(Origin::signed(origin), user_id));
+        assert_ok!(PeaqRBAC::fetch_user_groups(
+            Origin::signed(origin),
+            origin,
+            user_id
+        ));
 
         // Test for non-existing user to group relationship
         let user_id = *b"15676474666576474646673646376637";
         assert_noop!(
-            PeaqRBAC::fetch_user_groups(Origin::signed(origin), user_id),
+            PeaqRBAC::fetch_user_groups(Origin::signed(origin), origin, user_id),
             Error::<Test>::EntityDoesNotExist
         );
     });
@@ -1001,6 +1019,7 @@ fn fetch_user_permissions_test() {
 
         assert_ok!(PeaqRBAC::fetch_user_permissions(
             Origin::signed(origin),
+            origin,
             user_id
         ));
     });
@@ -1048,6 +1067,7 @@ fn fetch_group_permissions_test() {
 
         assert_ok!(PeaqRBAC::fetch_group_permissions(
             Origin::signed(origin),
+            origin,
             group_id
         ));
     });


### PR DESCRIPTION
* added owner param to all fetch to limit results to an account.
* optimize role store and fetch calls so that only owners role can be fetched. Roles are now assigned to owner AccountId as key on storage.
* optimize permission store and fetch calls so that only owners permission can be fetched. Permissions are now assigned to owner AccountId as key on storage.
* optimize group store and fetch calls so that only owmers group can be fetched. Groups are now assigned to owner AccountId as key on storage.
* optimized fetching single entity.