### PR TITLE
Fix the benchmark fail

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! The RBAC pallet allows resolving and management for  role-base access control in a generic manner.
 
+#![recursion_limit = "256"]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;


### PR DESCRIPTION
Fix the runtime benchmarking fails by adding the recursion macro.