### PR TITLE
Feature/1204578025047310 try runtime integration

### DIFF
--- a/pallet/src/error.rs
+++ b/pallet/src/error.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use sp_std::vec::Vec;
 
 /// Result definition for RBAC pallet with unique error type
-pub type Result<T> = core::result::Result<T, RbacError>;
+pub type Result<T, RbacError> = core::result::Result<T, RbacError>;
 
 /// All possible user error types of the RBAC pallet than can occur, when passing
 /// wrong or invalid parameters. Must be serialize-able when used via RPC.
@@ -41,7 +41,7 @@ pub struct RbacError {
 
 impl RbacError {
     /// generates a new RbacError including Result
-    pub fn err<T, EntityId: Parameter>(typ: RbacErrorType, data: &EntityId) -> Result<T> {
+    pub fn err<T, EntityId: Parameter>(typ: RbacErrorType, data: &EntityId) -> Result<T, RbacError> {
         // this transformation makes it possible to use RbacError without generic
         let param = data.encode().as_slice().to_vec();
         Err(RbacError { typ, param })

--- a/pallet/src/lib.rs
+++ b/pallet/src/lib.rs
@@ -684,7 +684,7 @@ pub mod pallet {
             owner: &T::AccountId,
             entity_id: &T::EntityId,
             tag: Tag,
-        ) -> Result<Entity<T::EntityId>> {
+        ) -> Result<Entity<T::EntityId>, RbacError> {
             let key = Self::generate_key(owner, entity_id, tag);
 
             if !<KeysLookUpStore<T>>::contains_key(&key) {
@@ -704,7 +704,7 @@ pub mod pallet {
             owner: &T::AccountId,
             entity_id: &T::EntityId,
             tag: Tag,
-        ) -> Result<RbacKeyType> {
+        ) -> Result<RbacKeyType, RbacError> {
             let key = Self::generate_key(owner, entity_id, tag);
 
             if !<KeysLookUpStore<T>>::contains_key(&key) {
@@ -723,7 +723,7 @@ pub mod pallet {
         fn get_user_roles(
             owner: &T::AccountId,
             user_id: T::EntityId,
-        ) -> Result<Vec<Role2User<T::EntityId>>> {
+        ) -> Result<Vec<Role2User<T::EntityId>>, RbacError> {
             // Generate key for integrity check
             let key = Self::generate_key(owner, &user_id, Tag::Role2User);
 
@@ -737,7 +737,7 @@ pub mod pallet {
         fn get_user_groups(
             owner: &T::AccountId,
             user_id: T::EntityId,
-        ) -> Result<Vec<User2Group<T::EntityId>>> {
+        ) -> Result<Vec<User2Group<T::EntityId>>, RbacError> {
             // Generate key for integrity check
             let key = Self::generate_key(owner, &user_id, Tag::User2Group);
 
@@ -751,7 +751,7 @@ pub mod pallet {
         fn get_group_roles(
             owner: &T::AccountId,
             group_id: T::EntityId,
-        ) -> Result<Vec<Role2Group<T::EntityId>>> {
+        ) -> Result<Vec<Role2Group<T::EntityId>>, RbacError> {
             // Generate key for integrity check
             let key = Self::generate_key(owner, &group_id, Tag::Role2Group);
 
@@ -765,7 +765,7 @@ pub mod pallet {
         fn get_role_permissions(
             owner: &T::AccountId,
             role_id: T::EntityId,
-        ) -> Result<Vec<Permission2Role<T::EntityId>>> {
+        ) -> Result<Vec<Permission2Role<T::EntityId>>, RbacError> {
             // Generate key for integrity check
             let key = Self::generate_key(owner, &role_id, Tag::Permission2Role);
 
@@ -779,7 +779,7 @@ pub mod pallet {
         fn get_user_permissions(
             owner: &T::AccountId,
             user_id: T::EntityId,
-        ) -> Result<Vec<Entity<T::EntityId>>> {
+        ) -> Result<Vec<Entity<T::EntityId>>, RbacError> {
             // Generate key for integrity check
             let role_2_user_key = Self::generate_key(owner, &user_id, Tag::Role2User);
             let user_2_group_key = Self::generate_key(owner, &user_id, Tag::User2Group);
@@ -841,7 +841,7 @@ pub mod pallet {
         fn get_group_permissions(
             owner: &T::AccountId,
             group_id: T::EntityId,
-        ) -> Result<Vec<Entity<T::EntityId>>> {
+        ) -> Result<Vec<Entity<T::EntityId>>, RbacError> {
             // Generate key for integrity check
 
             let mut permissions: Vec<Entity<T::EntityId>> = vec![];
@@ -870,7 +870,7 @@ pub mod pallet {
             owner: &T::AccountId,
             role_id: T::EntityId,
             user_id: T::EntityId,
-        ) -> Result<()> {
+        ) -> Result<(), RbacError> {
             // Generate key for integrity check
             let role_key = Self::generate_key(owner, &role_id, Tag::Role);
             let role_2_user_key = Self::generate_key(owner, &user_id, Tag::Role2User);
@@ -908,7 +908,7 @@ pub mod pallet {
             owner: &T::AccountId,
             role_id: T::EntityId,
             user_id: T::EntityId,
-        ) -> Result<()> {
+        ) -> Result<(), RbacError> {
             // Generate key for integrity check
             let role_2_user_key = Self::generate_key(owner, &user_id, Tag::Role2User);
 
@@ -948,7 +948,7 @@ pub mod pallet {
             owner: &T::AccountId,
             role_id: T::EntityId,
             group_id: T::EntityId,
-        ) -> Result<()> {
+        ) -> Result<(), RbacError> {
             // Generate key for integrity check
             let group_key = Self::generate_key(owner, &group_id, Tag::Group);
             let role_key = Self::generate_key(owner, &role_id, Tag::Role);
@@ -992,7 +992,7 @@ pub mod pallet {
             owner: &T::AccountId,
             role_id: T::EntityId,
             group_id: T::EntityId,
-        ) -> Result<()> {
+        ) -> Result<(), RbacError> {
             // Generate key for integrity check
             let role_2_group_key = Self::generate_key(owner, &group_id, Tag::Role2Group);
 
@@ -1032,7 +1032,7 @@ pub mod pallet {
             owner: &T::AccountId,
             user_id: T::EntityId,
             group_id: T::EntityId,
-        ) -> Result<()> {
+        ) -> Result<(), RbacError> {
             // Generate key for integrity check
             let group_key = Self::generate_key(owner, &group_id, Tag::Group);
             let user_2_group_key = Self::generate_key(owner, &user_id, Tag::User2Group);
@@ -1070,7 +1070,7 @@ pub mod pallet {
             owner: &T::AccountId,
             user_id: T::EntityId,
             group_id: T::EntityId,
-        ) -> Result<()> {
+        ) -> Result<(), RbacError> {
             // Generate key for integrity check
             let user_2_group_key = Self::generate_key(owner, &user_id, Tag::User2Group);
 
@@ -1110,7 +1110,7 @@ pub mod pallet {
             owner: &T::AccountId,
             permission_id: T::EntityId,
             role_id: T::EntityId,
-        ) -> Result<()> {
+        ) -> Result<(), RbacError> {
             // Generate key for integrity check
             let role_key = Self::generate_key(owner, &role_id, Tag::Role);
             let permission_key = Self::generate_key(owner, &permission_id, Tag::Permission);
@@ -1154,7 +1154,7 @@ pub mod pallet {
             owner: &T::AccountId,
             permission_id: T::EntityId,
             role_id: T::EntityId,
-        ) -> Result<()> {
+        ) -> Result<(), RbacError> {
             // Generate key for integrity check
             let permission_2_role_key = Self::generate_key(owner, &role_id, Tag::Permission2Role);
 
@@ -1202,15 +1202,15 @@ pub mod pallet {
 
     // implement the role Entity trait to satify the methods
     impl<T: Config> Role<T::AccountId, T::EntityId> for Pallet<T> {
-        fn get_role(owner: &T::AccountId, role_id: T::EntityId) -> Result<Entity<T::EntityId>> {
+        fn get_role(owner: &T::AccountId, role_id: T::EntityId) -> Result<Entity<T::EntityId>, RbacError> {
             Self::get_entity(&owner, &role_id, Tag::Role)
         }
 
-        fn get_roles(owner: &T::AccountId) -> Result<Vec<Entity<T::EntityId>>> {
+        fn get_roles(owner: &T::AccountId) -> Result<Vec<Entity<T::EntityId>>, RbacError> {
             Ok(<RoleStore<T>>::get(&owner))
         }
 
-        fn create_role(owner: &T::AccountId, role_id: T::EntityId, name: &[u8]) -> Result<()> {
+        fn create_role(owner: &T::AccountId, role_id: T::EntityId, name: &[u8]) -> Result<(), RbacError> {
             // Generate key for integrity check
             let key = Self::generate_key(owner, &role_id, Tag::Role);
 
@@ -1244,7 +1244,7 @@ pub mod pallet {
             owner: &T::AccountId,
             role_id: T::EntityId,
             name: &[u8],
-        ) -> Result<()> {
+        ) -> Result<(), RbacError> {
             // Check if role exists and it's enabled
             let key = Self::check_entity_get_key(owner, &role_id, Tag::Role)?;
 
@@ -1268,7 +1268,7 @@ pub mod pallet {
             Ok(())
         }
 
-        fn disable_existing_role(owner: &T::AccountId, role_id: T::EntityId) -> Result<()> {
+        fn disable_existing_role(owner: &T::AccountId, role_id: T::EntityId) -> Result<(), RbacError> {
             // Check if role exists and it's enabled and get key for integrity check
             let key = Self::check_entity_get_key(owner, &role_id, Tag::Role)?;
 
@@ -1295,11 +1295,11 @@ pub mod pallet {
         fn get_permission(
             owner: &T::AccountId,
             permission_id: T::EntityId,
-        ) -> Result<Entity<T::EntityId>> {
+        ) -> Result<Entity<T::EntityId>, RbacError> {
             Self::get_entity(&owner, &permission_id, Tag::Permission)
         }
 
-        fn get_permissions(owner: &T::AccountId) -> Result<Vec<Entity<T::EntityId>>> {
+        fn get_permissions(owner: &T::AccountId) -> Result<Vec<Entity<T::EntityId>>, RbacError> {
             Ok(<PermissionStore<T>>::get(&owner))
         }
 
@@ -1307,7 +1307,7 @@ pub mod pallet {
             owner: &T::AccountId,
             permission_id: T::EntityId,
             name: &[u8],
-        ) -> Result<()> {
+        ) -> Result<(), RbacError> {
             // Generate key for integrity check
             let key = Self::generate_key(owner, &permission_id, Tag::Permission);
 
@@ -1341,7 +1341,7 @@ pub mod pallet {
             owner: &T::AccountId,
             permission_id: T::EntityId,
             name: &[u8],
-        ) -> Result<()> {
+        ) -> Result<(), RbacError> {
             // Check if permission exists and it's enabled and get key for integrity check
             let key = Self::check_entity_get_key(owner, &permission_id, Tag::Permission)?;
 
@@ -1367,7 +1367,7 @@ pub mod pallet {
         fn disable_existing_permission(
             owner: &T::AccountId,
             permission_id: T::EntityId,
-        ) -> Result<()> {
+        ) -> Result<(), RbacError> {
             // Check if permission exists and it's enabled and get key for integrity check
             let key = Self::check_entity_get_key(owner, &permission_id, Tag::Permission)?;
 
@@ -1392,15 +1392,15 @@ pub mod pallet {
     }
 
     impl<T: Config> Group<T::AccountId, T::EntityId> for Pallet<T> {
-        fn get_group(owner: &T::AccountId, group_id: T::EntityId) -> Result<Entity<T::EntityId>> {
+        fn get_group(owner: &T::AccountId, group_id: T::EntityId) -> Result<Entity<T::EntityId>, RbacError> {
             Self::get_entity(&owner, &group_id, Tag::Group)
         }
 
-        fn get_groups(owner: &T::AccountId) -> Result<Vec<Entity<T::EntityId>>> {
+        fn get_groups(owner: &T::AccountId) -> Result<Vec<Entity<T::EntityId>>, RbacError> {
             Ok(<GroupStore<T>>::get(owner))
         }
 
-        fn create_group(owner: &T::AccountId, group_id: T::EntityId, name: &[u8]) -> Result<()> {
+        fn create_group(owner: &T::AccountId, group_id: T::EntityId, name: &[u8]) -> Result<(), RbacError> {
             // Generate key for integrity check
             let key = Self::generate_key(owner, &group_id, Tag::Group);
 
@@ -1434,7 +1434,7 @@ pub mod pallet {
             owner: &T::AccountId,
             group_id: T::EntityId,
             name: &[u8],
-        ) -> Result<()> {
+        ) -> Result<(), RbacError> {
             // Check if group exists and it's enabled and get key for integrity check
             let key = Self::check_entity_get_key(owner, &group_id, Tag::Group)?;
 
@@ -1454,7 +1454,7 @@ pub mod pallet {
             Ok(())
         }
 
-        fn disable_existing_group(owner: &T::AccountId, group_id: T::EntityId) -> Result<()> {
+        fn disable_existing_group(owner: &T::AccountId, group_id: T::EntityId) -> Result<(), RbacError> {
             // Check if group exists and it's enabled and get key for integrity check
             let key = Self::check_entity_get_key(owner, &group_id, Tag::Group)?;
             let mut val = <GroupStore<T>>::get(owner);

--- a/pallet/src/rbac.rs
+++ b/pallet/src/rbac.rs
@@ -2,101 +2,102 @@ use crate::structs::*;
 use sp_std::vec::Vec;
 
 pub use crate::error::Result;
+use crate::error::RbacError;
 
 pub type RbacKeyType = [u8; 32];
 
 pub trait Rbac<AccountId, EntityId> {
     fn generate_key(owner: &AccountId, entity: &EntityId, tag: Tag) -> RbacKeyType;
 
-    fn get_entity(owner: &AccountId, entity: &EntityId, tag: Tag) -> Result<Entity<EntityId>>;
+    fn get_entity(owner: &AccountId, entity: &EntityId, tag: Tag) -> Result<Entity<EntityId>, RbacError>;
 
-    fn check_entity_get_key(owner: &AccountId, entity: &EntityId, tag: Tag) -> Result<RbacKeyType>;
+    fn check_entity_get_key(owner: &AccountId, entity: &EntityId, tag: Tag) -> Result<RbacKeyType, RbacError>;
 
-    fn get_user_roles(owner: &AccountId, user_id: EntityId) -> Result<Vec<Role2User<EntityId>>>;
+    fn get_user_roles(owner: &AccountId, user_id: EntityId) -> Result<Vec<Role2User<EntityId>>, RbacError>;
 
-    fn get_user_groups(owner: &AccountId, user_id: EntityId) -> Result<Vec<User2Group<EntityId>>>;
+    fn get_user_groups(owner: &AccountId, user_id: EntityId) -> Result<Vec<User2Group<EntityId>>, RbacError>;
 
-    fn get_group_roles(owner: &AccountId, group_id: EntityId) -> Result<Vec<Role2Group<EntityId>>>;
+    fn get_group_roles(owner: &AccountId, group_id: EntityId) -> Result<Vec<Role2Group<EntityId>>, RbacError>;
 
     fn get_role_permissions(
         owner: &AccountId,
         role_id: EntityId,
-    ) -> Result<Vec<Permission2Role<EntityId>>>;
+    ) -> Result<Vec<Permission2Role<EntityId>>, RbacError>;
 
-    fn get_user_permissions(owner: &AccountId, user_id: EntityId) -> Result<Vec<Entity<EntityId>>>;
+    fn get_user_permissions(owner: &AccountId, user_id: EntityId) -> Result<Vec<Entity<EntityId>>, RbacError>;
 
     fn get_group_permissions(
         owner: &AccountId,
         group_id: EntityId,
-    ) -> Result<Vec<Entity<EntityId>>>;
+    ) -> Result<Vec<Entity<EntityId>>, RbacError>;
 
-    fn create_role_to_user(owner: &AccountId, role_id: EntityId, user_id: EntityId) -> Result<()>;
+    fn create_role_to_user(owner: &AccountId, role_id: EntityId, user_id: EntityId) -> Result<(), RbacError>;
 
-    fn revoke_role_to_user(owner: &AccountId, role_id: EntityId, user_id: EntityId) -> Result<()>;
+    fn revoke_role_to_user(owner: &AccountId, role_id: EntityId, user_id: EntityId) -> Result<(), RbacError>;
 
     fn create_role_to_group(owner: &AccountId, role_id: EntityId, group_id: EntityId)
-        -> Result<()>;
+        -> Result<(), RbacError>;
 
     fn revoke_role_to_group(owner: &AccountId, role_id: EntityId, group_id: EntityId)
-        -> Result<()>;
+        -> Result<(), RbacError>;
 
     fn create_user_to_group(owner: &AccountId, user_id: EntityId, group_id: EntityId)
-        -> Result<()>;
+        -> Result<(), RbacError>;
 
     fn revoke_user_to_group(owner: &AccountId, user_id: EntityId, group_id: EntityId)
-        -> Result<()>;
+        -> Result<(), RbacError>;
 
     fn create_permission_to_role(
         owner: &AccountId,
         permission_id: EntityId,
         role_id: EntityId,
-    ) -> Result<()>;
+    ) -> Result<(), RbacError>;
 
     fn revoke_permission_to_role(
         owner: &AccountId,
         permission_id: EntityId,
         role_id: EntityId,
-    ) -> Result<()>;
+    ) -> Result<(), RbacError>;
 }
 
 pub trait Role<AccountId, EntityId> {
-    fn get_role(owner: &AccountId, role_id: EntityId) -> Result<Entity<EntityId>>;
+    fn get_role(owner: &AccountId, role_id: EntityId) -> Result<Entity<EntityId>, RbacError>;
 
-    fn get_roles(owner: &AccountId) -> Result<Vec<Entity<EntityId>>>;
+    fn get_roles(owner: &AccountId) -> Result<Vec<Entity<EntityId>>, RbacError>;
 
-    fn create_role(owner: &AccountId, role_id: EntityId, name: &[u8]) -> Result<()>;
+    fn create_role(owner: &AccountId, role_id: EntityId, name: &[u8]) -> Result<(), RbacError>;
 
-    fn update_existing_role(owner: &AccountId, role_id: EntityId, name: &[u8]) -> Result<()>;
+    fn update_existing_role(owner: &AccountId, role_id: EntityId, name: &[u8]) -> Result<(), RbacError>;
 
-    fn disable_existing_role(owner: &AccountId, role_id: EntityId) -> Result<()>;
+    fn disable_existing_role(owner: &AccountId, role_id: EntityId) -> Result<(), RbacError>;
 }
 
 pub trait Permission<AccountId, EntityId> {
-    fn get_permission(owner: &AccountId, permission_id: EntityId) -> Result<Entity<EntityId>>;
+    fn get_permission(owner: &AccountId, permission_id: EntityId) -> Result<Entity<EntityId>, RbacError>;
 
-    fn get_permissions(owner: &AccountId) -> Result<Vec<Entity<EntityId>>>;
+    fn get_permissions(owner: &AccountId) -> Result<Vec<Entity<EntityId>>, RbacError>;
 
-    fn create_permission(owner: &AccountId, permission_id: EntityId, name: &[u8]) -> Result<()>;
+    fn create_permission(owner: &AccountId, permission_id: EntityId, name: &[u8]) -> Result<(), RbacError>;
 
     fn update_existing_permission(
         owner: &AccountId,
         permission_id: EntityId,
         name: &[u8],
-    ) -> Result<()>;
+    ) -> Result<(), RbacError>;
 
-    fn disable_existing_permission(owner: &AccountId, permission_id: EntityId) -> Result<()>;
+    fn disable_existing_permission(owner: &AccountId, permission_id: EntityId) -> Result<(), RbacError>;
 }
 
 pub trait Group<AccountId, EntityId> {
-    fn get_group(owner: &AccountId, group_id: EntityId) -> Result<Entity<EntityId>>;
+    fn get_group(owner: &AccountId, group_id: EntityId) -> Result<Entity<EntityId>, RbacError>;
 
-    fn get_groups(owner: &AccountId) -> Result<Vec<Entity<EntityId>>>;
+    fn get_groups(owner: &AccountId) -> Result<Vec<Entity<EntityId>>, RbacError>;
 
-    fn create_group(owner: &AccountId, group_id: EntityId, name: &[u8]) -> Result<()>;
+    fn create_group(owner: &AccountId, group_id: EntityId, name: &[u8]) -> Result<(), RbacError>;
 
-    fn update_existing_group(owner: &AccountId, group_id: EntityId, name: &[u8]) -> Result<()>;
+    fn update_existing_group(owner: &AccountId, group_id: EntityId, name: &[u8]) -> Result<(), RbacError>;
 
-    fn disable_existing_group(owner: &AccountId, group_id: EntityId) -> Result<()>;
+    fn disable_existing_group(owner: &AccountId, group_id: EntityId) -> Result<(), RbacError>;
 }
 
 pub enum Tag {

--- a/rpc/runtime-api/src/lib.rs
+++ b/rpc/runtime-api/src/lib.rs
@@ -8,6 +8,7 @@ use codec::Codec;
 use peaq_pallet_rbac::{
     rbac::Result as RbacResult,
     structs::{Entity, Permission2Role, Role2Group, Role2User, User2Group},
+    error::RbacError
 };
 use sp_std::vec::Vec;
 
@@ -17,28 +18,28 @@ sp_api::decl_runtime_apis! {
         AccountId: Codec,
         EntityId: Codec
     {
-        fn fetch_role(account: AccountId, entity: EntityId) -> RbacResult<Entity<EntityId>>;
+        fn fetch_role(account: AccountId, entity: EntityId) -> RbacResult<Entity<EntityId>, RbacError>;
 
-        fn fetch_roles(owner: AccountId) -> RbacResult<Vec<Entity<EntityId>>>;
+        fn fetch_roles(owner: AccountId) -> RbacResult<Vec<Entity<EntityId>>, RbacError>;
 
-        fn fetch_user_roles(owner: AccountId, user_id: EntityId) -> RbacResult<Vec<Role2User<EntityId>>>;
+        fn fetch_user_roles(owner: AccountId, user_id: EntityId) -> RbacResult<Vec<Role2User<EntityId>>, RbacError>;
 
-        fn fetch_permission(owner: AccountId, permission_id: EntityId) -> RbacResult<Entity<EntityId>>;
+        fn fetch_permission(owner: AccountId, permission_id: EntityId) -> RbacResult<Entity<EntityId>, RbacError>;
 
-        fn fetch_permissions(owner: AccountId) -> RbacResult<Vec<Entity<EntityId>>>;
+        fn fetch_permissions(owner: AccountId) -> RbacResult<Vec<Entity<EntityId>>, RbacError>;
 
-        fn fetch_role_permissions(owner: AccountId, role_id: EntityId) -> RbacResult<Vec<Permission2Role<EntityId>>>;
+        fn fetch_role_permissions(owner: AccountId, role_id: EntityId) -> RbacResult<Vec<Permission2Role<EntityId>>, RbacError>;
 
-        fn fetch_group(owner: AccountId, group_id: EntityId) -> RbacResult<Entity<EntityId>>;
+        fn fetch_group(owner: AccountId, group_id: EntityId) -> RbacResult<Entity<EntityId>, RbacError>;
 
-        fn fetch_groups(owner: AccountId) -> RbacResult<Vec<Entity<EntityId>>>;
+        fn fetch_groups(owner: AccountId) -> RbacResult<Vec<Entity<EntityId>>, RbacError>;
 
-        fn fetch_group_roles(owner: AccountId, group_id: EntityId) -> RbacResult<Vec<Role2Group<EntityId>>>;
+        fn fetch_group_roles(owner: AccountId, group_id: EntityId) -> RbacResult<Vec<Role2Group<EntityId>>, RbacError>;
 
-        fn fetch_user_groups(owner: AccountId, user_id: EntityId) -> RbacResult<Vec<User2Group<EntityId>>>;
+        fn fetch_user_groups(owner: AccountId, user_id: EntityId) -> RbacResult<Vec<User2Group<EntityId>>, RbacError>;
 
-        fn fetch_user_permissions(owner: AccountId, user_id: EntityId) -> RbacResult<Vec<Entity<EntityId>>>;
+        fn fetch_user_permissions(owner: AccountId, user_id: EntityId) -> RbacResult<Vec<Entity<EntityId>>, RbacError>;
 
-        fn fetch_group_permissions(owner: AccountId, group_id: EntityId) -> RbacResult<Vec<Entity<EntityId>>>;
+        fn fetch_group_permissions(owner: AccountId, group_id: EntityId) -> RbacResult<Vec<Entity<EntityId>>, RbacError>;
     }
 }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -13,12 +13,13 @@ use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 use sp_std::{vec, vec::Vec};
 
 use peaq_pallet_rbac::{
-    rbac::Result as RbacResult,
+    rbac::{Result as RbacResult, Rbac},
     structs::{Entity, Permission2Role, Role2Group, Role2User, User2Group},
+    error::RbacError
 };
 pub use peaq_pallet_rbac_runtime_api::PeaqRBACRuntimeApi;
 
-pub type Result<T> = RpcResult<RbacResult<T>>;
+pub type Result<T> = RpcResult<RbacResult<T, RbacError>>;
 
 /// Trait defines RBAC-RPC interface
 #[rpc(client, server)]


### PR DESCRIPTION
Fixed the issue that was causing build fail on peaq-network-node when using the try-runtime feature. 
Adds a redundant layer of 'Result' associate type over the core::result::Result, however, removing this layer would be problematic and require additional testing.